### PR TITLE
Bump plugin.cfg version to 0.1.5

### DIFF
--- a/meshy-godot-plugin/plugin.cfg
+++ b/meshy-godot-plugin/plugin.cfg
@@ -3,5 +3,5 @@
 name="Meshy official plugin"
 description="Bridge between Meshy and Godot."
 author="Meshy"
-version="0.1.3"
+version="0.1.5"
 script="meshy_plugin.gd"


### PR DESCRIPTION
The Auto Release workflow rewrites the version only inside its CI checkout, so the committed `plugin.cfg` had drifted behind the published releases (still `0.1.3` while the latest release is `v0.1.5`). Sync it to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)