### PR TITLE
Fix plugin preload paths (load failure on flat install), bump to 0.1.6

### DIFF
--- a/meshy-godot-plugin/meshy_plugin.gd
+++ b/meshy-godot-plugin/meshy_plugin.gd
@@ -1,7 +1,7 @@
 @tool
 extends EditorPlugin
 
-const MainPanel = preload("res://addons/meshy-godot-plugin/meshy-godot-plugin/main_panel.tscn")
+const MainPanel = preload("main_panel.tscn")
 
 var main_panel_instance: CenterContainer
 
@@ -34,7 +34,7 @@ func _get_plugin_name() -> String:
 
 
 func _get_plugin_icon() -> Texture2D:
-	var icon = preload("res://addons/meshy-godot-plugin/meshy-godot-plugin/Meshy_Icon_36.png")
+	var icon = preload("Meshy_Icon_36.png")
 	if icon:
 		return icon
 	return get_editor_interface().get_base_control().get_theme_icon("Node", "EditorIcons")

--- a/meshy-godot-plugin/plugin.cfg
+++ b/meshy-godot-plugin/plugin.cfg
@@ -3,5 +3,5 @@
 name="Meshy official plugin"
 description="Bridge between Meshy and Godot."
 author="Meshy"
-version="0.1.5"
+version="0.1.6"
 script="meshy_plugin.gd"


### PR DESCRIPTION
## Problem

`meshy_plugin.gd` preloaded `main_panel.tscn` and `Meshy_Icon_36.png` via a hardcoded, doubly-nested path:

```
res://addons/meshy-godot-plugin/meshy-godot-plugin/...
```

The released zip is flat (`addons/meshy-godot-plugin/<files>`), so on a normal install those preloads point at a directory that doesn't exist and the plugin fails to load:

```
Parse Error: Preload file "res://addons/meshy-godot-plugin/meshy-godot-plugin/main_panel.tscn" does not exist.
```

This regressed in v0.1.3 (v0.1.2 used the correct single-level path) and has shipped broken through v0.1.5. It only appeared to work in a doubly-nested install layout.

## Fix

Use sibling-relative preload paths so the plugin loads regardless of the install folder / nesting, and bump the version to 0.1.6.

Verified on a clean flat install: plugin loads, no parse errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)